### PR TITLE
Update for Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21
+          go-version: 1.26
 
       - name: Unit tests
         run: go test -coverprofile=cover.out ./...
@@ -27,10 +27,11 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: cover.out
+        continue-on-error: true
 
       - name: Modver
         if: ${{ github.event_name == 'pull_request' }}
-        uses: bobg/modver@v2.6.1
+        uses: bobg/modver@v2.13.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.26
+          go-version: '1.26'
 
       - name: Unit tests
         run: go test -coverprofile=cover.out ./...

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,8 @@ It also adds a function for traversing an error’s tree of wrapped sub-errors.
 
 This module began as a fork of the venerable [github.com/pkg/errors](https://github.com/pkg/errors).
 That module’s GitHub repository has been frozen for a long time and has not kept up with changes to the standard library.
-(For example, it does not export [the Join function](https://pkg.go.dev/errors#Join) added in Go 1.20.)
+(For example, it does not export [the Join function](https://pkg.go.dev/errors#Join) added in Go 1.20,
+or [the AsType function](https://pkg.go.dev/errors#AsType) added in Go 1.26.)
 
 This is now a brand-new implementation with a different API.
 

--- a/dropin.go
+++ b/dropin.go
@@ -38,6 +38,23 @@ func As(err error, target any) bool {
 	return errors.As(err, target)
 }
 
+// AsType finds the first error in err's tree that matches the type E, and
+// if one is found, returns that error value and true. Otherwise, it
+// returns the zero value of E and false.
+//
+// The tree consists of err itself, followed by the errors obtained by
+// repeatedly calling its Unwrap() error or Unwrap() []error method. When
+// err wraps multiple errors, AsType examines err followed by a
+// depth-first traversal of its children.
+//
+// An error err matches the type E if the type assertion err.(E) holds,
+// or if the error has a method As(any) bool such that err.As(target)
+// returns true when target is a non-nil *E. In the latter case, the As
+// method is responsible for setting target.
+func AsType[E error](err error) (E, bool) {
+	return errors.AsType[E](err)
+}
+
 // Is reports whether any error in err's tree matches target.
 //
 // The tree consists of err itself, followed by the errors obtained by repeatedly

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/bobg/errors
 
-go 1.21
-
-toolchain go1.21.6
+go 1.26

--- a/walk.go
+++ b/walk.go
@@ -45,10 +45,6 @@ func Walk(e error, f func(error) error) error {
 // ErrSkip can be used by the callback to [Walk] to skip an error's subtree without aborting the walk.
 var ErrSkip = New("skip")
 
-type singleUnwrap interface {
-	Unwrap() error
-}
-
 type multiUnwrap interface {
 	Unwrap() []error
 }

--- a/walk.go
+++ b/walk.go
@@ -30,7 +30,7 @@ func Walk(e error, f func(error) error) error {
 		return Walk(u, f)
 	}
 
-	if multi, ok := e.(interface{ Unwrap() []error }); ok {
+	if multi, ok := e.(multiUnwrap); ok {
 		uu := multi.Unwrap()
 		for _, ue := range uu {
 			if err := Walk(ue, f); err != nil {
@@ -44,3 +44,11 @@ func Walk(e error, f func(error) error) error {
 
 // ErrSkip can be used by the callback to [Walk] to skip an error's subtree without aborting the walk.
 var ErrSkip = New("skip")
+
+type singleUnwrap interface {
+	Unwrap() error
+}
+
+type multiUnwrap interface {
+	Unwrap() []error
+}


### PR DESCRIPTION
This PR adds `errors.AsType`, tracking the change in the standard library.